### PR TITLE
refactor: centralize shape trimming logic

### DIFF
--- a/map-refiner/src/main/java/org/foobar/mapRefiner/OpenLRDecoder.java
+++ b/map-refiner/src/main/java/org/foobar/mapRefiner/OpenLRDecoder.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static org.foobar.mapRefiner.LocationReferenceParser.generateCsvFromDecodedResult;
 import static org.foobar.mapRefiner.LocationReferenceParser.parsePrettyPrintString;
 import static org.foobar.mapRefiner.RouteMatcher.*;
+import static org.foobar.mapRefiner.ShapeProcessor.getTrimmedShape;
 
 public class OpenLRDecoder {
     private static final ObjectMapper objectMapper = new ObjectMapper();

--- a/map-refiner/src/main/java/org/foobar/mapRefiner/RouteMatcher.java
+++ b/map-refiner/src/main/java/org/foobar/mapRefiner/RouteMatcher.java
@@ -1,5 +1,4 @@
 package org.foobar.mapRefiner;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -19,64 +18,6 @@ public class RouteMatcher {
     private static final String ROUTE_MATCHING_URL = "https://routematching.hereapi.com/v8/match/routelinks?"
             + "apiKey=" + HERE_API_KEY
             + "&routeMatch=1&mode=car&mapMatchRadius=20";
-
-
-    public static List<double[]> getTrimmedShape(List<double[]> shape, int positiveOffset, int negativeOffset) {
-        double totalLength = 0.0;
-
-        List<Double> segmentLengths = new ArrayList<>();
-
-        for (int i = 0; i < shape.size() - 1; i++) {
-            double distance = haversineDistance(shape.get(i), shape.get(i + 1));
-            segmentLengths.add(distance);
-            totalLength += distance;
-        }
-
-        double startTrimmedLength = 0.0;
-        int startIndex = 0;
-        while (startIndex < segmentLengths.size() && startTrimmedLength + segmentLengths.get(startIndex) < positiveOffset) {
-            startTrimmedLength += segmentLengths.get(startIndex);
-            startIndex++;
-        }
-
-        // 若 negativeOffset == 0，計算 positiveOffset 在 shape 上的準確座標
-        if (negativeOffset == -1) {
-            if (startIndex == 0) {
-                return List.of(shape.get(0)); // 直接返回第一個點
-            }
-            if (startIndex >= shape.size()) {
-                return List.of(shape.get(shape.size() - 1)); // 如果超過範圍，回傳最後一個點
-            }
-
-            double remainingDistance = positiveOffset - startTrimmedLength;
-            double[] startPoint = shape.get(startIndex - 1);
-            double[] endPoint = shape.get(startIndex);
-
-            double segmentDistance = segmentLengths.get(startIndex - 1);
-            if (segmentDistance == 0) {
-                return List.of(startPoint); // 避免除以零，直接返回該點
-            }
-
-            double fraction = remainingDistance / segmentDistance;
-            double interpolatedLat = startPoint[0] + fraction * (endPoint[0] - startPoint[0]);
-            double interpolatedLon = startPoint[1] + fraction * (endPoint[1] - startPoint[1]);
-
-            return List.of(new double[]{interpolatedLat, interpolatedLon});
-        } else if (negativeOffset == 0) {
-            return shape.subList(startIndex, segmentLengths.size());
-        }
-
-        double endTrimmedLength = 0.0;
-        int endIndex = segmentLengths.size();
-        while (endIndex > 0 && endTrimmedLength + segmentLengths.get(endIndex - 1) < negativeOffset) {
-            endTrimmedLength += segmentLengths.get(endIndex - 1);
-            endIndex--;
-        }
-
-        return shape.subList(startIndex, endIndex);
-    }
-
-
     public static List<double[]> fetchRouteShape(JsonNode matchedRouteResponse) {
         List<double[]> shape = new ArrayList<>();
         JsonNode legs = matchedRouteResponse.path("response").path("route").path(0).path("leg");
@@ -150,25 +91,6 @@ public class RouteMatcher {
         try (InputStream is = conn.getInputStream()) {
             return objectMapper.readTree(is);
         }
-    }
-
-    private static double haversineDistance(double[] point1, double[] point2) {
-        double R = 6371000;
-        double lat1 = Math.toRadians(point1[0]);
-        double lon1 = Math.toRadians(point1[1]);
-        double lat2 = Math.toRadians(point2[0]);
-        double lon2 = Math.toRadians(point2[1]);
-
-        double dLat = lat2 - lat1;
-        double dLon = lon2 - lon1;
-
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                Math.cos(lat1) * Math.cos(lat2) *
-                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
-
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-        return R * c;
     }
 
 }

--- a/map-refiner/src/main/java/org/foobar/mapRefiner/ShapeProcessor.java
+++ b/map-refiner/src/main/java/org/foobar/mapRefiner/ShapeProcessor.java
@@ -22,19 +22,43 @@ public class ShapeProcessor {
             startIndex++;
         }
 
-        int endIndex = segmentLengths.size();
-        if (negativeOffset > 0) {
-            double endTrimmedLength = 0.0;
-            while (endIndex > 0 && endTrimmedLength + segmentLengths.get(endIndex - 1) < negativeOffset) {
-                endTrimmedLength += segmentLengths.get(endIndex - 1);
-                endIndex--;
+        if (negativeOffset == -1) {
+            if (startIndex == 0) {
+                return List.of(shape.get(0));
             }
+            if (startIndex >= shape.size()) {
+                return List.of(shape.get(shape.size() - 1));
+            }
+
+            double remainingDistance = positiveOffset - startTrimmedLength;
+            double[] startPoint = shape.get(startIndex - 1);
+            double[] endPoint = shape.get(startIndex);
+
+            double segmentDistance = segmentLengths.get(startIndex - 1);
+            if (segmentDistance == 0) {
+                return List.of(startPoint);
+            }
+
+            double fraction = remainingDistance / segmentDistance;
+            double interpolatedLat = startPoint[0] + fraction * (endPoint[0] - startPoint[0]);
+            double interpolatedLon = startPoint[1] + fraction * (endPoint[1] - startPoint[1]);
+
+            return List.of(new double[]{interpolatedLat, interpolatedLon});
+        } else if (negativeOffset == 0) {
+            return shape.subList(startIndex, segmentLengths.size());
+        }
+
+        double endTrimmedLength = 0.0;
+        int endIndex = segmentLengths.size();
+        while (endIndex > 0 && endTrimmedLength + segmentLengths.get(endIndex - 1) < negativeOffset) {
+            endTrimmedLength += segmentLengths.get(endIndex - 1);
+            endIndex--;
         }
 
         return shape.subList(startIndex, endIndex);
     }
 
-    private static double haversineDistance(double[] point1, double[] point2) {
+    public static double haversineDistance(double[] point1, double[] point2) {
         double R = 6371000;
         double lat1 = Math.toRadians(point1[0]);
         double lon1 = Math.toRadians(point1[1]);


### PR DESCRIPTION
## Summary
- expose ShapeProcessor.haversineDistance and consolidate getTrimmedShape
- remove duplicate trimming code from RouteMatcher
- use ShapeProcessor.getTrimmedShape in OpenLRDecoder

## Testing
- `mvn -q -pl map-refiner -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d5a3fcec8331ba131b8835b14429