### PR TITLE
Refactor OpenLR decoder into modular private methods

### DIFF
--- a/map-refiner/src/main/java/org/foobar/mapRefiner/OpenLRDecoder.java
+++ b/map-refiner/src/main/java/org/foobar/mapRefiner/OpenLRDecoder.java
@@ -29,85 +29,89 @@ public class OpenLRDecoder {
 
     public static Map<String, Object> decodeOpenLR(String base64Data, boolean performMapMatching, boolean isApiCall) {
         try {
-            OpenLRLocationReference reference;
-
-            try {
-                byte[] decode = Base64.getDecoder().decode(base64Data);
-                reference = BinaryMarshallers.openLRLocationReference()
-                        .unmarshall(new ByteArrayInputStream(decode));
-
-                if (reference.getLocationReference() == null) {
-                    throw new UnableToDecodeException("Invalid OpenLR data: Decoded reference is null.");
-                }
-            } catch (IllegalArgumentException e) {
-                throw new UnableToDecodeException("Invalid Base64 encoding: " + e.getMessage());
-            } catch (AssertionError e) {
-                throw new UnableToDecodeException("Invalid OpenLR format: " + e.getMessage());
-            } catch (Exception e) {
-                throw new UnableToDecodeException("Unexpected error while decoding OpenLR, please input proper OpenLR Base64 string.");
-            }
-
-//            System.out.println("getLocationReference: " + reference.getLocationReference().toString());
-            ObjectMapper mapper = new ObjectMapper();
-            String parsedJson = "";
-
-            if (reference.getLocationReference().toString().startsWith("LinearLocationReference")) {
-                LinearLocationReference reference1 = (LinearLocationReference) reference.getLocationReference();
-                parsedJson = parsePrettyPrintString((OlrPrettyPrinter.prettyPrint(reference1).toString()), mapper);
-            } else {
-                parsedJson = LocationReferenceParser.parseToJson(reference.getLocationReference().toString());
-            }
+            OpenLRLocationReference reference = decodeBase64(base64Data);
+            String parsedJson = parseLocationReference(reference);
             Map<String, Object> jsonMap = objectMapper.readValue(parsedJson, Map.class);
+
             if (!isApiCall) {
                 return jsonMap;
-            } else{
-                if (performMapMatching) {
-                    JsonNode decodedResult = objectMapper.readTree(parsedJson);
-
-                    if (!decodedResult.has("type")) {
-                        throw new UnableToDecodeException("Decoded OpenLR data is missing required fields.");
-                    }
-
-                    String csvData = generateCsvFromDecodedResult(decodedResult);
-                    JsonNode matchedRouteResponse = fetchMatchedRoute(csvData);
-
-                    List<double[]> fullShape = fetchRouteShape(matchedRouteResponse);
-
-//            List<String> linkIdList = fetchLinkIds(matchedRouteResponse);
-
-//            List<String> segmentRefList = fetchSegmentRefs(matchedRouteResponse);
-
-                    int positiveOffset = (int) jsonMap.getOrDefault("positiveOffset", 0);
-                    int negativeOffset = decodedResult.has("negativeOffset") ? decodedResult.get("negativeOffset").asInt() : -1;
-
-                    List<double[]> trimmedShape = getTrimmedShape(fullShape, positiveOffset, negativeOffset);
-//                    System.out.printf("trimmedShape.size(): %s", trimmedShape.size());
-
-                    String shapeStyle = trimmedShape.size() == 1 ? "point" : "polyline";
-                    String flexiblePolyline = PolylineUtil.encodeToFlexiblePolyline(trimmedShape);
-
-                    return Map.of(
-                            "input", base64Data,
-                            "decoded_result", jsonMap,
-                            "map_matched_shape", Map.of(
-                                    "style", shapeStyle,
-                                    "trimmed_shape", trimmedShape,
-                                    "flexible_polyline", flexiblePolyline)
-                    );
-                } else {
-                    return Map.of(
-                            "input", base64Data,
-                            "decoded_result", jsonMap
-                    );
-                }
             }
 
-
-
+            Map<String, Object> mapMatchedShape = performMapMatching ? performMapMatching(parsedJson, jsonMap) : null;
+            return buildResponse(base64Data, jsonMap, mapMatchedShape);
         } catch (UnableToDecodeException e) {
             return Map.of("error", e.getMessage(), "input", base64Data);
         } catch (Exception e) {
             return Map.of("error", "Unexpected error occurred");
+        }
+    }
+
+    private static OpenLRLocationReference decodeBase64(String base64Data) {
+        try {
+            byte[] decode = Base64.getDecoder().decode(base64Data);
+            OpenLRLocationReference reference = BinaryMarshallers.openLRLocationReference()
+                    .unmarshall(new ByteArrayInputStream(decode));
+
+            if (reference.getLocationReference() == null) {
+                throw new UnableToDecodeException("Invalid OpenLR data: Decoded reference is null.");
+            }
+            return reference;
+        } catch (IllegalArgumentException e) {
+            throw new UnableToDecodeException("Invalid Base64 encoding: " + e.getMessage());
+        } catch (AssertionError e) {
+            throw new UnableToDecodeException("Invalid OpenLR format: " + e.getMessage());
+        } catch (Exception e) {
+            throw new UnableToDecodeException("Unexpected error while decoding OpenLR, please input proper OpenLR Base64 string.");
+        }
+    }
+
+    private static String parseLocationReference(OpenLRLocationReference reference) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        if (reference.getLocationReference().toString().startsWith("LinearLocationReference")) {
+            LinearLocationReference reference1 = (LinearLocationReference) reference.getLocationReference();
+            return parsePrettyPrintString((OlrPrettyPrinter.prettyPrint(reference1).toString()), mapper);
+        } else {
+            return LocationReferenceParser.parseToJson(reference.getLocationReference().toString());
+        }
+    }
+
+    private static Map<String, Object> performMapMatching(String parsedJson, Map<String, Object> jsonMap) throws Exception {
+        JsonNode decodedResult = objectMapper.readTree(parsedJson);
+
+        if (!decodedResult.has("type")) {
+            throw new UnableToDecodeException("Decoded OpenLR data is missing required fields.");
+        }
+
+        String csvData = generateCsvFromDecodedResult(decodedResult);
+        JsonNode matchedRouteResponse = fetchMatchedRoute(csvData);
+        List<double[]> fullShape = fetchRouteShape(matchedRouteResponse);
+
+        int positiveOffset = (int) jsonMap.getOrDefault("positiveOffset", 0);
+        int negativeOffset = decodedResult.has("negativeOffset") ? decodedResult.get("negativeOffset").asInt() : -1;
+
+        List<double[]> trimmedShape = getTrimmedShape(fullShape, positiveOffset, negativeOffset);
+        String shapeStyle = trimmedShape.size() == 1 ? "point" : "polyline";
+        String flexiblePolyline = PolylineUtil.encodeToFlexiblePolyline(trimmedShape);
+
+        return Map.of(
+                "style", shapeStyle,
+                "trimmed_shape", trimmedShape,
+                "flexible_polyline", flexiblePolyline
+        );
+    }
+
+    private static Map<String, Object> buildResponse(String base64Data, Map<String, Object> jsonMap, Map<String, Object> mapMatchedShape) {
+        if (mapMatchedShape != null) {
+            return Map.of(
+                    "input", base64Data,
+                    "decoded_result", jsonMap,
+                    "map_matched_shape", mapMatchedShape
+            );
+        } else {
+            return Map.of(
+                    "input", base64Data,
+                    "decoded_result", jsonMap
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Break down `decodeOpenLR` into smaller private helpers for decoding, parsing, map matching and response building.
- Public `decodeOpenLR` now orchestrates these helpers and wraps errors with `UnableToDecodeException`.

## Testing
- `mvn -q -pl map-refiner test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d88dda788331b1a86e793705be6d